### PR TITLE
Update3, to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,39 @@
 
 (you should now be able to call `iav_serotype` from the command line to bring up the help menu)
 
-5) Download and unpack database files from Zenodo (~115 MB total). `cd` to the directory you want them to live.
+5) Download and unpack database files from Zenodo (~1.7 GB total). `cd` to the directory you want them to live.
 
-`wget https://zenodo.org/records/11123391/files/Influenza_A_segment_sequences.tar.gz`
+`wget https://zenodo.org/records/11509609/files/Influenza_A_segment_sequences.tar.gz`
 
 `tar -xvf Influenza_A_segment_sequences.tar.gz`
 
 
 You should now have these 2 files:
 
-`DBs/v1.1/Influenza_A_segment_info1.tsv`
+`DBs/v1.25/Influenza_A_segment_info1.tsv`
 
-`DBs/v1.1/Influenza_A_segment_sequences.fna`
+`DBs/v1.25/Influenza_A_segment_sequences.fna`
 
 6) (optional) set database as conda environmental variable
 
-`conda env config vars set IAVS_DB=/path/to/DBs/v1.1`
+`conda env config vars set IAVS_DB=/path/to/DBs/v1.25`
+
+
+# Update (if necessary)
+
+Latest version is `v0.1.2`
+
+
+1) `pip uninstall iav_serotype`
+
+2) `cd influenza_a_serotype`
+
+3) `git pull`
+
+4) `pip install .`
+
+5) `iav_serotype --version`
+
 
 # Run `iav_serotype`
 
@@ -54,13 +71,29 @@ Right now, requirement is either 1 set of paired-end short reads per run, or 1 o
 
 short paired-end reads:
 
-`iav_serotype -r my_reads/virome.R1.fastq my_reads/virome.R2.fastq -s my_virome_iav -o iav_project --db /path/to/DBs/v1.1`
+`iav_serotype -r my_reads/virome.R1.fastq my_reads/virome.R2.fastq -s my_virome_iav -o iav_project --db /path/to/DBs/v1.25`
 
 long reads:
 
-`iav_serotype -r long_reads/virome1.fastq long_reads/virome2.fastq long_reads/virome3.fastq -s my_lr_virome_iav -o iav_project --db /path/to/DBs/v1.1`
+`iav_serotype -r long_reads/virome1.fastq long_reads/virome2.fastq long_reads/virome3.fastq -s my_lr_virome_iav -o iav_project --db /path/to/DBs/v1.25`
 
 # Database notes
+
+## v1.25
+
+NOTE: Use database `v1.25` with `iav_serotype v0.1.2` or later. a small number of added reference sequences have short sequences that were likely assembled into the genome by mistake. These will cause assignment of reads as "ambiguous" IAV in `iav_serotype v0.1.1`, but these alignments are filtered out in `iav_serotype v0.1.2`. Thank you.
+
+Description:
+
+Fresh download of all complete influenza A sequences + metadata tables from NCBI virus. Consists of 981,537 complete segements.
+
+1) Search and download date=2024-06-05, NCBI virus taxid=2955291, length filter( 3000 > 700 )
+
+2) Then, sequences and metadata were parsed to remove any duplicate accessions and any sequences with uninformative serotype labels, e.g. "H3", "mixed", "HxNx".
+
+3) Finally, low complexity regions were masked with `bbmask.sh` with default parameters for low-complexity filtering (available with `bbtools`)
+
+[Zenodo](https://zenodo.org/records/11509609)
 
 ## v1.1
 
@@ -90,6 +123,4 @@ Note: I'm working on getting a more complete database, as I think there is relev
 
 # Future updates
 
-1) Update database to have comprehensive influenza A coverage.
-
-2) Add Influenza B, C, and D
+1) Add Influenza B, C, and D

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ long reads:
 
 ## v1.25
 
-NOTE: Use database `v1.25` with `iav_serotype v0.1.2` or later. a small number of added reference sequences have short sequences that were likely assembled into the genome by mistake. These will cause assignment of reads as "ambiguous" IAV in `iav_serotype v0.1.1`, but these alignments are filtered out in `iav_serotype v0.1.2`. Thank you.
+NOTE: Use database `v1.25` with `iav_serotype v0.1.2` or later. A small number of added reference sequences have short sequences that were likely assembled into the genome by mistake. These will cause assignment of non-specific reads as "ambiguous" IAV in `iav_serotype v0.1.1`, but these alignments are filtered out in `iav_serotype v0.1.2`. Thank you.
 
 Description:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "iav_serotype"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Mike Tisza", email="michael.tisza@gmail.com" },
 ]

--- a/src/iav_serotype/iav_serotype.py
+++ b/src/iav_serotype/iav_serotype.py
@@ -111,7 +111,7 @@ def iav_serotype():
 
     parentpath = Path(pathname).parents[1]
 
-    __version__ = "0.1.1"
+    __version__ = "0.1.2"
 
     Def_CPUs = os.cpu_count()
 
@@ -156,7 +156,7 @@ def iav_serotype():
                                 These can add up, so it is not recommended if space is a concern.')
     optional_args.add_argument("-p", "--read_format", 
                             dest="READ_FMT", type=str, choices=['short_paired', 'long'], default='short_paired',
-                            help='ONLY SUPPORTING PAIRED RIGHT NOW. Must be 2 files.')
+                            help='default = short_paired. short_paired must provide 2 .fastq files.')
 
     optional_args.add_argument("--db", 
                             dest="DB", type=str, default='default',

--- a/src/iav_serotype/parse_pafs_influenza_A.R
+++ b/src/iav_serotype/parse_pafs_influenza_A.R
@@ -62,10 +62,8 @@ sum_dt <- assigment_dt %>%
   mutate(read_assignment = case_when(
     (max(top_score - 0.003)) >= min(top_score) |
       n_distinct(serotype) == 1 ~ first(serotype),
-    TRUE ~ "ambiguous"),
-    read_assignment = case_when(max(top_score) < 
-                                  score_thresh ~ "ambiguous",
-                                TRUE ~ read_assignment))
+    TRUE ~ "ambiguous")) %>%
+  filter(max(top_score) >= score_thresh)
 
 write.table(sum_dt,
             file = sprintf("%s/%s_read_summary.tsv", 


### PR DESCRIPTION
Mainly, changing filtering out alignments below (ANI*AF) threshold instead of recording them as ambiguous. This is how it should have been set, originally.

Database version `v1.25` is being release simultaneously. See database notes.